### PR TITLE
Update browser tab title and remove React branding

### DIFF
--- a/factory-ui/public/index.html
+++ b/factory-ui/public/index.html
@@ -2,14 +2,12 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"
       content="Web site created using create-react-app"
     />
-    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
@@ -24,7 +22,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>FactoryUI</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/factory-ui/public/manifest.json
+++ b/factory-ui/public/manifest.json
@@ -1,23 +1,6 @@
 {
-  "short_name": "React App",
-  "name": "Create React App Sample",
-  "icons": [
-    {
-      "src": "favicon.ico",
-      "sizes": "64x64 32x32 24x24 16x16",
-      "type": "image/x-icon"
-    },
-    {
-      "src": "logo192.png",
-      "type": "image/png",
-      "sizes": "192x192"
-    },
-    {
-      "src": "logo512.png",
-      "type": "image/png",
-      "sizes": "512x512"
-    }
-  ],
+  "short_name": "FactoryUI",
+  "name": "FactoryUI - Visual Workflow Builder",
   "start_url": ".",
   "display": "standalone",
   "theme_color": "#000000",


### PR DESCRIPTION
- Change page title from 'React App' to 'FactoryUI'
- Remove React favicon and apple-touch-icon references
- Update manifest.json with FactoryUI branding
- Remove all icon references from manifest to eliminate React logos

🤖 Generated with [Claude Code](https://claude.ai/code)